### PR TITLE
fix: update API response parsing in category page

### DIFF
--- a/front/src/app/[locale]/categories/[category]/page.tsx
+++ b/front/src/app/[locale]/categories/[category]/page.tsx
@@ -20,8 +20,8 @@ async function getData(category: string): Promise<TArtPiece[]> {
 		if (!response.ok) {
 			throw new Error(`Failed to fetch artpieces: ${response.status}`);
 		}
-		const { artPieces }: { artPieces: TArtPiece[] } = await response.json();
-		return artPieces;
+		const { results }: { results: TArtPiece[] } = await response.json();
+		return results;
 	} catch (error) {
 		console.error(`Помилка при завантаженні арт-об'єктів: ${error}`);
 		return [];


### PR DESCRIPTION
Changed the data extraction from the API response to use the 'results' property instead of 'artPieces' when fetching art pieces for a category.