### PR TITLE
Dev danyil

### DIFF
--- a/front/src/ui/components/modal/order/modal-order-fill.tsx
+++ b/front/src/ui/components/modal/order/modal-order-fill.tsx
@@ -16,7 +16,26 @@ const ModalOrderFill: React.FC<ModalFillOrderProps> = ({ artPiece }) => {
 			aria-modal="true"
 			aria-labelledby="modal-title"
 			aria-describedby="modal-description"
-			className="flex flex-row bg-white w-fit h-fit relative xl:max-w-[90vw] xl:max-h-[90vh] pt-4 sm:pt-0">
+			className="flex flex-row bg-white w-fit h-fit relative xl:max-w-[90vw] xl:max-h-[90vh] pt-4 sm:pt-0"
+			onClick={(e) => {
+				const target = e.target as HTMLElement;
+				const isInteractive = !!target.closest(
+					"button, a, input, textarea, select, label, [role='button']"
+				);
+				if (!isInteractive) {
+					e.preventDefault();
+				}
+				e.stopPropagation();
+			}}
+			onPointerDown={(e) => {
+				e.stopPropagation();
+			}}
+			onMouseDown={(e) => {
+				e.stopPropagation();
+			}}
+			onTouchStart={(e) => {
+				e.stopPropagation();
+			}}>
 			<ModalButtonClose variable="light" />
 			{!isMobile && (
 				<div className="flex-grow-1 overflow-auto scrollbar-hide bg-black-1000">

--- a/front/src/ui/components/segment-title/move-to-link.tsx
+++ b/front/src/ui/components/segment-title/move-to-link.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import Link from "~/bridge/ui/Link";
 import Arrow from "~/assets/arrow-right.svg";
 
 interface MoveToLinkProps {
@@ -10,7 +10,7 @@ interface MoveToLinkProps {
 
 export function MoveToLink({ to, name }: MoveToLinkProps) {
 	return (
-		<Link href={to} className="font-fixel text-4 font-medium">
+		<Link to={to} className="font-fixel text-4 font-medium">
 			<span className="mr-2 hidden sm:inline-block">{name}</span>
 			<Arrow className="inline-block" height={24} width={24} />
 		</Link>

--- a/front/src/ui/components/segment-title/segment-title.tsx
+++ b/front/src/ui/components/segment-title/segment-title.tsx
@@ -1,5 +1,4 @@
 import { MoveToLink } from "./move-to-link";
-import usePath from "~/ui/hooks/usePath";
 
 interface SegmentTitleProps {
 	children?: string;
@@ -15,12 +14,11 @@ export default function SegmentTitle({
 	link,
 	className = "",
 }: SegmentTitleProps) {
-	const pathCreator = usePath()
 	return (
 		<div
 			className={`flex justify-between items-center h-12 border-bottom ${className}`}>
 			<h3 className="text-5 lg:text-6 font-namu">{children}</h3>
-			{link && <MoveToLink to={pathCreator(link.to)} name={link.name} />}
+			{link && <MoveToLink to={link.to} name={link.name} />}
 		</div>
 	);
 }

--- a/front/src/ui/components/slider/slider-fullscreen.tsx
+++ b/front/src/ui/components/slider/slider-fullscreen.tsx
@@ -62,14 +62,30 @@ const SliderFullscreen: FC<TSliderBaseProps> = ({
 				<>
 					<div
 						className={`bg-gradient-light backdrop-blur-md pr-4 before:bg-gradient-light before:backdrop-blur-md before:absolute before:-left-[100%] before:w-[100%] before:h-full xl:pr-0 xl:w-full`}>
-						<Turnabout
-							currentIndex={currentSlideIdx}
-							text={slides.map(({ title }) => title)}
-							tag={"h1"}
-							textClass="font-namu text-8 md:text-12 lg:text-20 text-black leading-none py-2"
-							animation="ease-in-out"
-							duration={600}
-						/>
+						<div className="relative">
+							{/* Placeholder reserves height to prevent jump on init */}
+							<div
+								aria-hidden
+								className="opacity-0 font-namu text-8 md:text-12 lg:text-20 leading-none py-2">
+								{slides.reduce(
+									(longest, s) =>
+										(s.title?.length || 0) > (longest.length || 0)
+											? s.title || ""
+											: longest,
+									""
+								)}
+							</div>
+							<div className="absolute inset-0">
+								<Turnabout
+									currentIndex={currentSlideIdx}
+									text={slides.map(({ title }) => title)}
+									tag={"h1"}
+									textClass="font-namu text-8 md:text-12 lg:text-20 text-black leading-none py-2"
+									animation="ease-in-out"
+									duration={600}
+								/>
+							</div>
+						</div>
 					</div>
 					{!isDesktop && (
 						<SliderButtonExpand

--- a/front/src/ui/components/turnabout/turnabout.tsx
+++ b/front/src/ui/components/turnabout/turnabout.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useLayoutEffect } from "react";
 
 interface TurnaboutProps
 	extends React.ComponentPropsWithoutRef<React.ElementType> {
@@ -24,9 +24,7 @@ const Turnabout: React.FC<TurnaboutProps> = ({
 	textClass,
 }) => {
 	const refs = useRef<(HTMLDivElement | null)[]>([]);
-	const containerRef = useRef<HTMLDivElement | null>(null);
 	const [heights, setHeights] = useState<number[]>([]);
-	const [currentHeight, setCurrentHeight] = useState<number>(0);
 
 	const validatedIndex = currentIndex >= text.length ? 0 : currentIndex;
 
@@ -34,37 +32,48 @@ const Turnabout: React.FC<TurnaboutProps> = ({
 		if (el) refs.current[index] = el;
 	}, []);
 
-	useEffect(() => {
+	// Measure item heights before paint to avoid visible jump
+	useLayoutEffect(() => {
 		const newHeights = refs.current.map((el) => el?.offsetHeight || 0);
 		setHeights(newHeights);
-
-		setTimeout(() => {
-			if (newHeights[validatedIndex] !== undefined) {
-				setCurrentHeight(newHeights[validatedIndex]);
-			}
-		}, 10);
-	}, [text, validatedIndex]);
+	}, [text]);
 
 	const translateY = heights
 		.slice(0, validatedIndex)
 		.reduce((acc, h) => acc + h, 0);
 
+	const placeholderText = text.reduce((longest, t) => {
+		const a = longest || "";
+		const b = t || "";
+		return b.length > a.length ? b : a;
+	}, "");
+
 	return (
-		<div
-			ref={containerRef}
-			className={`relative overflow-hidden transition-[height] duration-300 ease-in-out ${wrapperClass}`}
-			style={{ height: `${currentHeight}px`, minHeight: "1em" }}>
-			<div
-				className={`flex flex-col transition-transform duration-[${duration}ms] ${animation}`}
-				style={{ transform: `translateY(-${translateY}px)` }}>
-				{text.map((textItem, index) => (
-					<Tag
-						key={index}
-						ref={(el: any) => setRef(el, index)}
-						className={textClass}>
-						{textItem}
-					</Tag>
-				))}
+		<div className={`relative overflow-hidden ${wrapperClass}`}>
+			{/* Invisible placeholder reserves space on first paint to prevent layout shift */}
+			<Tag
+				aria-hidden
+				className={`${textClass} opacity-0 select-none pointer-events-none`}>
+				{placeholderText}
+			</Tag>
+			<div className="absolute inset-0">
+				<div
+					className={`flex flex-col`}
+					style={{
+						transform: `translateY(-${translateY}px)`,
+						transitionProperty: "transform",
+						transitionDuration: `${duration}ms`,
+						transitionTimingFunction: animation,
+					}}>
+					{text.map((textItem, index) => (
+						<Tag
+							key={index}
+							ref={(el: any) => setRef(el, index)}
+							className={textClass}>
+							{textItem}
+						</Tag>
+					))}
+				</div>
 			</div>
 		</div>
 	);

--- a/front/src/ui/pages/main-page/main-page.tsx
+++ b/front/src/ui/pages/main-page/main-page.tsx
@@ -14,16 +14,19 @@ export default ({ artPieces, slides, tagsFindBy }: TMainPage) => {
 			<MainSliderWrapper className="mb-12 lg:mb-8" slides={slides} />
 			<div className="container mx-auto min-h-[100vh]">
 				<SearchBar />
-				<FindByTags tags={tagsFindBy}/>
+				<FindByTags tags={tagsFindBy} />
 				<article className="mobile-spacing mt-10">
 					<section className="mb-10">
 						<SegmentTitle
 							className="mb-10"
-							link={{ to: "/", name: "всі нові надходження" }}>
+							link={{
+								to: "categories/new-arrivals",
+								name: "всі нові надходження",
+							}}>
 							Нові надходження
 						</SegmentTitle>
 						<div className="columns-1 gap-6 sm:columns-2 lg:columns-3 xl:columns-4 space-y-12">
-							{artPieces.slice(0,7).map((obj) => (
+							{artPieces.slice(0, 7).map((obj) => (
 								<CardPurchase key={obj.id} card={obj} />
 							))}
 						</div>


### PR DESCRIPTION
This pull request introduces several improvements to the UI components, focusing on layout stability, event handling, and code consistency. The most significant changes include preventing layout shifts in the `Turnabout` and `SliderFullscreen` components by reserving space with invisible placeholders, updating link handling for consistency, and enhancing modal event propagation control.

**Layout stability improvements:**

* Added invisible placeholder elements to the `Turnabout` (`turnabout.tsx`) and `SliderFullscreen` (`slider-fullscreen.tsx`) components to reserve space and prevent layout jumps when content changes. This uses the longest text value as a placeholder and measures heights before paint using `useLayoutEffect`. [[1]](diffhunk://#diff-4a10bd809e8209a3eb27886dd1671a0c63461d0858e92265ee893ec1fdaa7b8eL27-R67) [[2]](diffhunk://#diff-4a10bd809e8209a3eb27886dd1671a0c63461d0858e92265ee893ec1fdaa7b8eR78) [[3]](diffhunk://#diff-9da857f87020e393694af866cea07636290d3ae85641773e0c6af27258309d63R65-R78) [[4]](diffhunk://#diff-9da857f87020e393694af866cea07636290d3ae85641773e0c6af27258309d63R88-R89)

**Event handling enhancements:**

* Improved event propagation control in the modal component (`modal-order-fill.tsx`) by adding handlers for `onClick`, `onPointerDown`, `onMouseDown`, and `onTouchStart` to prevent unwanted bubbling and ensure interactions are limited to intended elements.

**Link and navigation consistency:**

* Updated the `MoveToLink` component to use the custom `Link` from `~/bridge/ui/Link` and changed the `to` prop for consistency, removing unnecessary path creation logic. [[1]](diffhunk://#diff-3bd78df00a52ba44c48ecd05a9bb8b80e5ece29c67b617c1471cc6329f13c152L3-R3) [[2]](diffhunk://#diff-3bd78df00a52ba44c48ecd05a9bb8b80e5ece29c67b617c1471cc6329f13c152L13-R13) [[3]](diffhunk://#diff-4149231e43b737511397781403cd47460289d8a3da9eff033f00db6c902b3cfcL2) [[4]](diffhunk://#diff-4149231e43b737511397781403cd47460289d8a3da9eff033f00db6c902b3cfcL18-R21)
* Changed the "Нові надходження" section link in `main-page.tsx` to point to `categories/new-arrivals` instead of the root path for improved navigation.